### PR TITLE
CLJS-2797: Prepare :method, :dot, js-value, and :case* for tools.analyzer AST conversion

### DIFF
--- a/src/main/clojure/cljs/core.cljc
+++ b/src/main/clojure/cljs/core.cljc
@@ -845,7 +845,7 @@
 
 (core/defn- simple-test-expr? [env ast]
   (core/and
-    (#{:var :invoke :const :dot :js} (:op ast))
+    (#{:var :invoke :const :host-field :host-call :js} (:op ast))
     ('#{boolean seq} (cljs.analyzer/infer-tag env ast))))
 
 (core/defmacro and
@@ -3065,7 +3065,7 @@
                c-1   (core/dec (count sig))
                meta  (assoc meta
                        :top-fn
-                       {:variadic true
+                       {:variadic? true
                         :max-fixed-arity c-1
                         :method-params [sig]
                         :arglists (core/list arglist)
@@ -3119,7 +3119,7 @@
                             [(core/- (count (first (filter varsig? arglists))) 2)]))
                meta     (assoc meta
                           :top-fn
-                          {:variadic variadic
+                          {:variadic? variadic
                            :max-fixed-arity maxfa
                            :method-params sigs
                            :arglists arglists


### PR DESCRIPTION
rename :method op to :fn-method

rename :expr entry to :body in :fn-method op

rename :max-fixed-arity to :fixed-arity in :fn-method op

rename :variadic to :variadic? in :fn-method op

split :dot op into :host-field/:host-call

split :js-value op into :js-object/:js-array

rename :case* op to :case

rename :v to :test in :case op

add :case-node grouping with :case-{test,then} in :case op